### PR TITLE
Remove extra `-` for training

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -10,7 +10,7 @@ Following the [quickstart](../README.md) installation, to start training seq2seq
 
 ```bash
 $ cd $ALFRED_ROOT
-$ python models/train/train_seq2seq.py --data data/json_feat_2.1.0 --model seq2seq_im_mask --dout exp/model:{model},name:pm_and_subgoals_01 --splits data/splits/oct21.json --gpu --batch 8 --pm_aux_loss_wt 0.2 --subgoal_aux_loss_wt 0.2 ---preprocess
+$ python models/train/train_seq2seq.py --data data/json_feat_2.1.0 --model seq2seq_im_mask --dout exp/model:{model},name:pm_and_subgoals_01 --splits data/splits/oct21.json --gpu --batch 8 --pm_aux_loss_wt 0.2 --subgoal_aux_loss_wt 0.2 --preprocess
 ```
 
 Run this **once with** `--preprocess` to save preprocessed JSONs inside the trajectory folders. This could take a few minutes, but subsequent runs can be deployed without any preprocessing. See [train_seq2seq.py](train/train_seq2seq.py) for hyper-parameters and other settings. 


### PR DESCRIPTION
Currently, there is an extra `-` added in model training code. `---preprocess` -> `--preprocess`.

Again, thanks for the amazing repository.