### PR TITLE
augment_trajectories walklevel too shallow

### DIFF
--- a/gen/scripts/augment_trajectories.py
+++ b/gen/scripts/augment_trajectories.py
@@ -292,10 +292,10 @@ parser.add_argument('--reward_config', type=str, default='../models/config/rewar
 args = parser.parse_args()
 
 # make a list of all the traj_data json files
-for dir_name, subdir_list, file_list in walklevel(args.data_path, level=2):
+for dir_name, subdir_list, file_list in walklevel(args.data_path, level=3):
     if "trial_" in dir_name:
         json_file = os.path.join(dir_name, TRAJ_DATA_JSON_FILENAME)
-        if not os.path.isfile(json_file):
+        if not os.path.isfile(json_file) or 'tests' in dir_name:
             continue
         traj_list.append(json_file)
 


### PR DESCRIPTION
python gen/scripts/tp_augment_trajectories.py --data_path data/json_2.1.0 --num_threads 1

original code leads to `traj_list` with 971 elements of the type:
```
'data/json_2.1.0/tests_seen/trial_T20190909_074728_844604/traj_data.json'
```

The above edits leads to `traj_list` with 7080 elements of the type:
```
'data/json_2.1.0/train/look_at_obj_in_light-AlarmClock-None-DeskLamp-301/trial_T20190907_174127_043461/traj_data.json'
```

Why?
Num separators in `args.data_path='data/json_2.1.0'` is 1
Num separators in `dir_name='data/json_2.1.0/tests_seen/trial_T20190909_074728_844604'` is 3 i.e. level gap of 2 
Num separators in `dir_name='data/json_2.1.0/train/look_at_obj_in_light-AlarmClock-None-DeskLamp-301/trial_T20190907_174127_043461'` is 4 i.e. level gap of 3
Hence, we need to walk with `level=3` to reach the train directories

Since users shouldn't process the `tests_seen` and `tests_unseen` directories (as per issue #14), we need the optional edit of `or 'tests' in dir_name`. It raises a `Error: KeyError('task_type',)` error.