### PR TITLE
fixes CoolObjectAction reward function

### DIFF
--- a/env/reward.py
+++ b/env/reward.py
@@ -242,8 +242,6 @@ class CoolObjectAction(BaseAction):
     valid_actions = {'OpenObject', 'CloseObject', 'PickupObject', 'PutObject'}
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self. = False
-        self.
 
     def get_reward(self, state, prev_state, expert_plan, goal_idx):
         if state.metadata['lastAction'] not in self.valid_actions:

--- a/env/reward.py
+++ b/env/reward.py
@@ -240,8 +240,6 @@ class CoolObjectAction(BaseAction):
     '''
 
     valid_actions = {'OpenObject', 'CloseObject', 'PickupObject', 'PutObject'}
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def get_reward(self, state, prev_state, expert_plan, goal_idx):
         if state.metadata['lastAction'] not in self.valid_actions:

--- a/env/thor_env.py
+++ b/env/thor_env.py
@@ -38,6 +38,10 @@ class ThorEnv(Controller):
         self.cooled_objects = set()
         self.heated_objects = set()
 
+        # intemediate states for CoolObject Subgoal
+        self.cooled_reward = False
+        self.reopen_reward = False
+
         print("ThorEnv started.")
 
     def reset(self, scene_name_or_num,


### PR DESCRIPTION
## What?
Corrected the Cooling reward function to implement the expected functionality for RL training. 

## Why?
The previous implementation prematurely marked the CoolObjectAction subgoal as completed immediately after the object was cooled (i.e. placed in the fridge and fridge door was closed). This created a poor/no incentive for the RL agent to pick up the cooled object before moving to the next subgoal. As a result, the previous function for RL training led to no success rate for completing the CoolObject subgoal. 

## How?
The CoolObjectAction reward function is modified as follows:
1. It marks the **CoolObject** subgoal completed only after the agent completes **all** of the following sequence of actions : Cool Object -> Reopen Fridge -> Pickup cooled object
2. It provides intermediate rewards for completing subparts of the cooling subgoal for denser reward feedback.

## Misc.
An agent trained with PPO with the revised CoolObjectAction function is able to successfully complete the task of _pick_cool_then_place_in_recep_.