### PR TITLE
Fix flask version for Socket compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ torch==1.1.0
 torchvision==0.3.0
 tensorboardX==1.8
 ai2thor==2.1.0
+flask==2.0.3
+Werkzeug==2.0.3


### PR DESCRIPTION
Current versions of flask break with `ai2thor==2.1.0` and give socket errors.

From Player.log:
```
(Filename: ./Runtime/Export/Debug.bindings.h Line: 45)

SocketException: The socket has been shut down
  at System.Net.Sockets.Socket.Send (System.Byte[] buf) [0x00000] in <filename unknown>:0
  at AgentManager+<EmitFrame>c__Iterator3.MoveNext () [0x00000] in <filename unknown>:0
  at UnityEngine.SetupCoroutine.InvokeMoveNext (IEnumerator enumerator, IntPtr returnValueAddress) [0x00000] in <>

(Filename:  Line: -1)
```

The solution is to fix `flask==2.0.3` and `Werzeug==2.0.3` as in #130. 